### PR TITLE
Fix OAuth2 callback 404 error by improving URL routing

### DIFF
--- a/devtools/web/.htaccess
+++ b/devtools/web/.htaccess
@@ -2,3 +2,7 @@ php_value max_input_vars 50000
 php_value max_input_nesting_level 256
 php_value memory_limit 1G
 php_value max_execution_time 600
+
+# OAuth2コールバック用URLリライト
+RewriteEngine On
+RewriteRule ^oauth2/callback$ /index.php [L,QSA]

--- a/devtools/web/index.php
+++ b/devtools/web/index.php
@@ -24,7 +24,15 @@ function adminer_object()
 }
 
 // OAuth2コールバック処理（Adminer実行前に処理）
-if (isset($_SERVER['REQUEST_URI']) && strpos($_SERVER['REQUEST_URI'], '/oauth2/callback') !== false) {
+$request_uri = $_SERVER['REQUEST_URI'] ?? '';
+$is_oauth_callback = strpos($request_uri, '/oauth2/callback') !== false ||
+                    (isset($_GET['code']) && isset($_GET['state']) && strpos($request_uri, 'oauth2') !== false);
+
+if ($is_oauth_callback) {
+	// デバッグログ出力
+	error_log('OAuth2 callback detected. REQUEST_URI: ' . $request_uri);
+	error_log('GET parameters: ' . json_encode($_GET));
+
 	// OAuth2コールバックURLの場合、BigQueryドライバーのOAuth2処理を実行
 	if (isset($_GET['code']) && isset($_GET['state'])) {
 		// BigQueryドライバーを読み込み


### PR DESCRIPTION
## 問題
本番環境でOAuth2コールバック（/oauth2/callback）が404エラーになる問題を修正

## 修正内容
1. **.htaccess設定追加**: /oauth2/callback パスをindex.phpにリライト
2. **コールバック検出の改善**: より確実なパスマッチング
3. **デバッグログ追加**: 問題の追跡を容易にする

## テスト
- ローカル環境でOAuth2フローの動作確認済み
- 本番環境での404エラー解決を期待

## 対応するエラーログ
```
10.21.2.217 - - [09/Oct/2025:22:26:00 +0000] "GET /oauth2/callback?state=...&code=... HTTP/1.1" 404 446
```