### PR TITLE
OAuth2リダイレクトURL形式の修正とドキュメント整理

### DIFF
--- a/devtools/issues/i06.md
+++ b/devtools/issues/i06.md
@@ -20,5 +20,3 @@
 	"GOOGLE_OAUTH2_COOKIE_SECRET":
 
 * 環境変数"GOOGLE_OAUTH2_ENABLE"がtureの場合、Google OAuth2認証で認証されたユーザの権限を使ってbigqueryの認証・認可を得るようにしてください。
-
-#

--- a/devtools/web/.htaccess
+++ b/devtools/web/.htaccess
@@ -2,7 +2,3 @@ php_value max_input_vars 50000
 php_value max_input_nesting_level 256
 php_value memory_limit 1G
 php_value max_execution_time 600
-
-# OAuth2コールバック用URLリライト
-RewriteEngine On
-RewriteRule ^oauth2/callback$ /index.php [L,QSA]

--- a/devtools/web/apache-custom.conf
+++ b/devtools/web/apache-custom.conf
@@ -7,3 +7,7 @@ LogFormat "%h %l %u %t \"%r\" %>s %O \"%{Referer}i\" \"%{User-Agent}i\"" combine
 # アクセスログとエラーログを標準出力・標準エラー出力にリダイレクト
 CustomLog /dev/stdout combined_custom env=!dontlog
 ErrorLog /dev/stderr
+
+# Adminer静的ファイルのエイリアス設定
+# /static/editing.js を /adminer/static/editing.js にリダイレクト
+Alias /static/editing.js /var/www/html/adminer/static/editing.js

--- a/devtools/web/compose.yml
+++ b/devtools/web/compose.yml
@@ -17,7 +17,7 @@ services:
       - GOOGLE_OAUTH2_ENABLE=false
       - GOOGLE_OAUTH2_CLIENT_ID=your-oauth2-client-id
       - GOOGLE_OAUTH2_CLIENT_SECRET=your-oauth2-client-secret
-      - GOOGLE_OAUTH2_REDIRECT_URL=http://localhost:8080/oauth2/callback
+      - GOOGLE_OAUTH2_REDIRECT_URL=http://localhost:8080/?oauth2=callback
       - GOOGLE_OAUTH2_COOKIE_DOMAIN=localhost
       - GOOGLE_OAUTH2_COOKIE_NAME=oauth2_token
       - GOOGLE_OAUTH2_COOKIE_EXPIRE=3600

--- a/devtools/web/index.php
+++ b/devtools/web/index.php
@@ -24,13 +24,12 @@ function adminer_object()
 }
 
 // OAuth2コールバック処理（Adminer実行前に処理）
-$request_uri = $_SERVER['REQUEST_URI'] ?? '';
-$is_oauth_callback = strpos($request_uri, '/oauth2/callback') !== false ||
-                    (isset($_GET['code']) && isset($_GET['state']) && strpos($request_uri, 'oauth2') !== false);
+$is_oauth_callback = isset($_GET['oauth2']) && $_GET['oauth2'] === 'callback' &&
+                    isset($_GET['code']) && isset($_GET['state']);
 
 if ($is_oauth_callback) {
 	// デバッグログ出力
-	error_log('OAuth2 callback detected. REQUEST_URI: ' . $request_uri);
+	error_log('OAuth2 callback detected. Query parameter oauth2=callback');
 	error_log('GET parameters: ' . json_encode($_GET));
 
 	// OAuth2コールバックURLの場合、BigQueryドライバーのOAuth2処理を実行


### PR DESCRIPTION
## Summary
- OAuth2リダイレクトURLをクエリパラメータ形式（`?oauth2=callback`）に修正
- `devtools/issues/i06.md`の不要な末尾記号を削除

これにより、AdminerのURL構造に適合したOAuth2コールバック処理が可能になります。

## Test plan
- [ ] `devtools/web`環境でOAuth2認証フローが正常に動作することを確認
- [ ] コールバックURL `http://localhost:8080/?oauth2=callback` が正しく処理されることを確認
- [ ] ドキュメントの記述に誤りがないことを確認

<!-- I want to review in Japanese. -->