### PR TITLE
Docker ECRベースイメージ変更によるAWS環境最適化

### DIFF
--- a/devtools/web/Dockerfile
+++ b/devtools/web/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage - Adminer本体の取得と依存関係インストール
-FROM php:8.3-apache AS build
+FROM public.ecr.aws/docker/library/php:8.3-apache
 
 # ビルド用ツールのインストール
 RUN apt-get update && apt-get install -y \

--- a/devtools/web/Dockerfile
+++ b/devtools/web/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage - Adminer本体の取得と依存関係インストール
-FROM public.ecr.aws/docker/library/php:8.3-apache
+FROM public.ecr.aws/docker/library/php:8.3-apache AS build
 
 # ビルド用ツールのインストール
 RUN apt-get update && apt-get install -y \
@@ -37,7 +37,7 @@ COPY composer.lock /app/
 RUN composer install --no-dev --optimize-autoloader
 
 # Production stage - 本番用最小イメージ
-FROM php:8.3-apache AS production
+FROM public.ecr.aws/docker/library/php:8.3-apache AS production
 
 # 本番用最小限パッケージのインストール
 RUN apt-get update \


### PR DESCRIPTION
## Summary
- DockerfileのベースイメージをAWS ECRパブリックレジストリに変更
- `FROM php:8.3-apache` → `FROM public.ecr.aws/docker/library/php:8.3-apache`
- AWS環境での構築効率化とイメージキャッシュ最適化を実現

## Test plan
- [ ] Docker Composeでのビルドとコンテナ起動確認
- [ ] AdminerのBigQueryプラグイン機能動作確認
- [ ] E2Eテストによる基本機能検証

<!-- I want to review in Japanese. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)