### PR TITLE
BigQuery開発用Claudeコマンドの追加

### DIFF
--- a/.claude/commands/rebuild-web.md
+++ b/.claude/commands/rebuild-web.md
@@ -1,0 +1,30 @@
+---
+description: webコンテナを停止・再ビルド・起動する（テスト実行なし）
+allowed-tools: Bash(*)
+---
+
+BigQuery Admin用webコンテナの再ビルドを実行します。
+
+## 実行内容
+コード変更後の反映に必要な一連のコンテナ操作を実行します：
+
+1. **既存コンテナ停止**: 現在実行中のwebコンテナを停止・削除
+2. **イメージ再ビルド**: 最新のコードでDockerイメージを再構築
+3. **コンテナ起動**: 新しいイメージでコンテナを起動
+4. **起動確認**: コンテナの正常起動を確認
+
+## 使用場面
+- BigQueryドライバーコード修正後
+- 設定ファイル（compose.yml、Dockerfile等）変更後
+- プラグインファイル更新後
+- 依存関係更新後
+
+## 実行コマンド
+```bash
+cd devtools/web
+docker compose down
+docker compose up --build -d
+docker ps | grep adminer-bigquery-test
+```
+
+⚠️ **重要**: Dockerコンテナ内のコードは初回ビルド時にコピーされるため、ホスト側のコード変更は再ビルドなしでは反映されません。

--- a/.claude/commands/test-web.md
+++ b/.claude/commands/test-web.md
@@ -1,0 +1,44 @@
+---
+description: BigQuery webコンテナをビルド・再起動してPlaywright MCPテストを実行
+allowed-tools: Bash(*), mcp__playwright__*
+---
+
+BigQuery Admin用webコンテナの完全テストフローを実行します。
+
+## 実行内容
+1. **webコンテナ停止**: 既存コンテナのクリーンアップ
+2. **webコンテナ再ビルド・起動**: 最新コードでのコンテナ作成
+3. **コンテナ状況確認**: 起動状況の検証
+4. **Playwright MCPテスト**: 実ブラウザでの機能テスト実行
+
+## テスト対象機能
+- BigQuery OAuth2認証プロセス
+- データセット一覧表示
+- テーブル一覧・構造表示
+- SELECT文実行・データ表示
+- ページング機能
+- UI操作・ナビゲーション
+
+## 実行手順
+
+### 1. webコンテナの停止・再ビルド
+```bash
+cd devtools/web
+docker compose down
+docker compose up --build -d
+```
+
+### 2. コンテナ起動確認
+```bash
+docker ps | grep adminer-bigquery-test
+```
+
+### 3. Playwright MCPテスト実行
+- BigQuery認証画面への接続
+- ログイン実行
+- データセット選択（dataset_test）
+- テーブルデータ表示（board_kpi）
+- 基本機能の動作確認
+- 各動作でFatalやError,Invalidなどの警告が画面に発生していないことを確認
+
+このコマンドにより、BigQueryドライバープラグインの包括的な動作検証が自動実行されます。


### PR DESCRIPTION
## Summary

BigQueryプロジェクトの開発効率を向上させるための2つの新しいClaudeコマンドを追加しました：

- `/rebuild-web`: webコンテナの停止・再ビルド・起動を自動化
- `/test-web`: webコンテナの再構築とPlaywright MCPテストの包括的実行

これらのコマンドにより、コード変更後のDockerコンテナ反映とE2Eテストが効率化され、開発サイクルが大幅に改善されます。

### 追加ファイル
- `.claude/commands/rebuild-web.md`: webコンテナ再構築専用コマンド
- `.claude/commands/test-web.md`: webコンテナ + Playwright MCP統合テストコマンド

## Test plan

- [x] Claudeコマンドファイルの構文と内容を確認
- [x] `/rebuild-web`コマンドの実行フローを検証
- [x] `/test-web`コマンドのPlaywright MCP統合テストフローを検証
- [x] 各コマンドの説明とallowed-toolsが適切に設定されていることを確認

<!-- I want to review in Japanese. -->